### PR TITLE
Much better glamor X11 performance.

### DIFF
--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -189,7 +189,7 @@ glamor_create_pixmap(ScreenPtr screen, int w, int h, int depth,
     if (w > 32767 || h > 32767)
         return NullPixmap;
 
-    if (depth == 8 && usage != GLAMOR_CREATE_FBO_NO_FBO ||
+    if ((depth == 8 && usage != GLAMOR_CREATE_FBO_NO_FBO) ||
 	(w == h && w == 24 && depth == 32)) {
         return fbCreatePixmap(screen, w, h, depth, usage);
     }
@@ -257,7 +257,8 @@ glamor_block_handler(ScreenPtr screen)
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
 
     glamor_make_current(glamor_priv);
-    glFinish();
+
+    glamor_flush();
 }
 
 static void
@@ -266,7 +267,8 @@ _glamor_block_handler(ScreenPtr screen, void *timeout)
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
 
     glamor_make_current(glamor_priv);
-    glFinish();
+
+    glamor_flush();
 
     screen->BlockHandler = glamor_priv->saved_procs.block_handler;
     screen->BlockHandler(screen, timeout);
@@ -878,5 +880,6 @@ glamor_finish(ScreenPtr screen)
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
 
     glamor_make_current(glamor_priv);
+
     glFinish();
 }

--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -881,5 +881,6 @@ glamor_finish(ScreenPtr screen)
 
     glamor_make_current(glamor_priv);
 
-    glFinish();
+    //glFinish();
+	glamor_flush();
 }

--- a/glamor/glamor_composite_glyphs.c
+++ b/glamor/glamor_composite_glyphs.c
@@ -285,14 +285,8 @@ glamor_glyphs_flush(CARD8 op, PicturePtr src, PicturePtr dst,
         prog++;
     }
 
-    {   // workround the lack of glyphs for firefox.
-        GLint fbo = 0;
-        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
-        if(0 != fbo) {
-            glBindFramebuffer(GL_FRAMEBUFFER, 0);
-            glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-        }
-    }
+    // workround the lack of glyphs for firefox.
+	glamor_flush();
 
     glDisable(GL_SCISSOR_TEST);
 

--- a/glamor/glamor_sync.c
+++ b/glamor/glamor_sync.c
@@ -52,8 +52,9 @@ glamor_sync_fence_set_triggered (SyncFence *fence)
 	struct glamor_sync_fence *glamor_fence = glamor_get_sync_fence(fence);
 
 	/* Flush pending rendering operations */
-        glamor_make_current(glamor);
-        glFinish();
+	glamor_make_current(glamor);
+
+	glamor_flush();
 
 	fence->funcs.SetTriggered = glamor_fence->set_triggered;
 	fence->funcs.SetTriggered(fence);

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -617,8 +617,8 @@ format_for_depth(int depth)
 static inline GLenum
 gl_iformat_for_pixmap(PixmapPtr pixmap)
 {
-    glamor_screen_private *glamor_priv =
-        glamor_get_screen_private((pixmap)->drawable.pScreen);
+//    glamor_screen_private *glamor_priv =
+//        glamor_get_screen_private((pixmap)->drawable.pScreen);
 
     if (((pixmap)->drawable.depth == 1 || (pixmap)->drawable.depth == 8)) {
         return GL_ALPHA;
@@ -749,5 +749,16 @@ glamor_glDrawArrays_GL_QUADS(glamor_screen_private *glamor_priv, unsigned count)
     }
 }
 
+/*
+ */
+static inline void glamor_flush(void)
+{
+	GLint fbo = 0;
+	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
+	if(0 != fbo) {
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+	}
+}
 
 #endif


### PR DESCRIPTION
Glamor with glFinish provides terrible performance under X11.
A workaround with framebuffer memory flushing works well on
r14p0-01rel0-git(966ed26).f44c85cb3d2ceb87e8be88e7592755c3

20-modesetting.conf:
Section "Device"
    Identifier  "Rockchip Graphics"
    Driver      "modesetting"
    Option      "AccelMethod"    "glamor"
    Option      "DRI"            "2"
    Option      "Dri2Vsync"      "false"
EndSection

gtkperf:
GtkEntry - time:  0.25
GtkComboBox - time:  2.63
GtkComboBoxEntry - time:  2.61
GtkSpinButton - time:  1.14
GtkProgressBar - time:  1.13
GtkToggleButton - time:  0.93
GtkCheckButton - time:  0.32
GtkRadioButton - time:  0.80
GtkTextView - Add text - time:  1.37